### PR TITLE
Avoid autofill via check for computed background color;

### DIFF
--- a/docs/static/bundle.js
+++ b/docs/static/bundle.js
@@ -636,9 +636,12 @@ module.exports = function () {
         this.textboxEl.addEventListener('focus', this._onFocusListener);
 
         // check for computed background color because of Chrome autofill bug
-        if (!hasValue(this.textboxEl) && getComputedStyle(this.textboxEl).backgroundColor !== 'rgb(250, 255, 189)') {
-            this.labelEl.classList.add(this.options.labelElementInlineModifier);
-        }
+        window.addEventListener('load', function () {
+            var isAutofilled = getComputedStyle(this.textboxEl).backgroundColor === 'rgb(250, 255, 189)';
+            if (!hasValue(this.textboxEl) && !isAutofilled) {
+                this.labelEl.classList.add(this.options.labelElementInlineModifier);
+            }
+        });
     }
 
     _createClass(_class, [{

--- a/docs/static/bundle.js
+++ b/docs/static/bundle.js
@@ -635,7 +635,8 @@ module.exports = function () {
         this.textboxEl.addEventListener('blur', this._onBlurListener);
         this.textboxEl.addEventListener('focus', this._onFocusListener);
 
-        if (!hasValue(this.textboxEl)) {
+        // check for computed background color because of Chrome autofill bug
+        if (!hasValue(this.textboxEl) && getComputedStyle(this.textboxEl).backgroundColor !== 'rgb(250, 255, 189)') {
             this.labelEl.classList.add(this.options.labelElementInlineModifier);
         }
     }

--- a/docs/static/bundle.js
+++ b/docs/static/bundle.js
@@ -636,12 +636,10 @@ module.exports = function () {
         this.textboxEl.addEventListener('focus', this._onFocusListener);
 
         // check for computed background color because of Chrome autofill bug
-        window.addEventListener('load', function () {
-            var isAutofilled = getComputedStyle(this.textboxEl).backgroundColor === 'rgb(250, 255, 189)';
-            if (!hasValue(this.textboxEl) && !isAutofilled) {
-                this.labelEl.classList.add(this.options.labelElementInlineModifier);
-            }
-        }.bind(this));
+        var isAutofilled = getComputedStyle(this.textboxEl).backgroundColor === 'rgb(250, 255, 189)';
+        if (!hasValue(this.textboxEl) && !isAutofilled) {
+            this.labelEl.classList.add(this.options.labelElementInlineModifier);
+        }
     }
 
     _createClass(_class, [{

--- a/docs/static/bundle.js
+++ b/docs/static/bundle.js
@@ -609,6 +609,8 @@ function hasValue(input) {
 }
 
 function isAutofilled(input) {
+    // check for computed background color because of Chrome autofill bug
+    // https://stackoverflow.com/questions/35049555/chrome-autofill-autocomplete-no-value-for-password/35783761#35783761
     return getComputedStyle(input).backgroundColor === 'rgb(250, 255, 189)';
 }
 

--- a/docs/static/bundle.js
+++ b/docs/static/bundle.js
@@ -641,7 +641,7 @@ module.exports = function () {
             if (!hasValue(this.textboxEl) && !isAutofilled) {
                 this.labelEl.classList.add(this.options.labelElementInlineModifier);
             }
-        });
+        }.bind(this));
     }
 
     _createClass(_class, [{

--- a/docs/static/bundle.js
+++ b/docs/static/bundle.js
@@ -608,6 +608,10 @@ function hasValue(input) {
     return input.value.length > 0;
 }
 
+function isAutofilled(input) {
+    return getComputedStyle(input).backgroundColor === 'rgb(250, 255, 189)';
+}
+
 function _onBlur() {
     if (!hasValue(this.textboxEl)) {
         this.labelEl.classList.add(this.options.labelElementInlineModifier);
@@ -635,9 +639,7 @@ module.exports = function () {
         this.textboxEl.addEventListener('blur', this._onBlurListener);
         this.textboxEl.addEventListener('focus', this._onFocusListener);
 
-        // check for computed background color because of Chrome autofill bug
-        var isAutofilled = getComputedStyle(this.textboxEl).backgroundColor === 'rgb(250, 255, 189)';
-        if (!hasValue(this.textboxEl) && !isAutofilled) {
+        if (!hasValue(this.textboxEl) && !isAutofilled(this.textboxEl)) {
             this.labelEl.classList.add(this.options.labelElementInlineModifier);
         }
     }
@@ -645,7 +647,7 @@ module.exports = function () {
     _createClass(_class, [{
         key: 'refresh',
         value: function refresh() {
-            if (hasValue(this.textboxEl)) {
+            if (hasValue(this.textboxEl) || isAutofilled(this.textboxEl)) {
                 this.labelEl.classList.remove(this.options.labelElementInlineModifier);
             } else {
                 this.labelEl.classList.add(this.options.labelElementInlineModifier);

--- a/index.js
+++ b/index.js
@@ -42,7 +42,8 @@ module.exports = function () {
         this.textboxEl.addEventListener('blur', this._onBlurListener);
         this.textboxEl.addEventListener('focus', this._onFocusListener);
 
-        if (!hasValue(this.textboxEl)) {
+        // check for computed background color because of Chrome autofill bug
+        if (!hasValue(this.textboxEl) && getComputedStyle(this.textboxEl).backgroundColor !== 'rgb(250, 255, 189)') {
             this.labelEl.classList.add(this.options.labelElementInlineModifier);
         }
     }

--- a/index.js
+++ b/index.js
@@ -43,12 +43,10 @@ module.exports = function () {
         this.textboxEl.addEventListener('focus', this._onFocusListener);
 
         // check for computed background color because of Chrome autofill bug
-        window.addEventListener('load', function () {
-            var isAutofilled = getComputedStyle(this.textboxEl).backgroundColor === 'rgb(250, 255, 189)';
-            if (!hasValue(this.textboxEl) && !isAutofilled) {
-                this.labelEl.classList.add(this.options.labelElementInlineModifier);
-            }
-        }.bind(this));
+        var isAutofilled = getComputedStyle(this.textboxEl).backgroundColor === 'rgb(250, 255, 189)';
+        if (!hasValue(this.textboxEl) && !isAutofilled) {
+            this.labelEl.classList.add(this.options.labelElementInlineModifier);
+        }
     }
 
     _createClass(_class, [{

--- a/index.js
+++ b/index.js
@@ -16,6 +16,8 @@ function hasValue(input) {
 }
 
 function isAutofilled(input) {
+    // check for computed background color because of Chrome autofill bug
+    // https://stackoverflow.com/questions/35049555/chrome-autofill-autocomplete-no-value-for-password/35783761#35783761
     return getComputedStyle(input).backgroundColor === 'rgb(250, 255, 189)';
 }
 

--- a/index.js
+++ b/index.js
@@ -43,9 +43,12 @@ module.exports = function () {
         this.textboxEl.addEventListener('focus', this._onFocusListener);
 
         // check for computed background color because of Chrome autofill bug
-        if (!hasValue(this.textboxEl) && getComputedStyle(this.textboxEl).backgroundColor !== 'rgb(250, 255, 189)') {
-            this.labelEl.classList.add(this.options.labelElementInlineModifier);
-        }
+        window.addEventListener('load', function () {
+            var isAutofilled = getComputedStyle(this.textboxEl).backgroundColor === 'rgb(250, 255, 189)';
+            if (!hasValue(this.textboxEl) && !isAutofilled) {
+                this.labelEl.classList.add(this.options.labelElementInlineModifier);
+            }
+        });
     }
 
     _createClass(_class, [{

--- a/index.js
+++ b/index.js
@@ -15,6 +15,10 @@ function hasValue(input) {
     return input.value.length > 0;
 }
 
+function isAutofilled(input) {
+    return getComputedStyle(input).backgroundColor === 'rgb(250, 255, 189)';
+}
+
 function _onBlur() {
     if (!hasValue(this.textboxEl)) {
         this.labelEl.classList.add(this.options.labelElementInlineModifier);
@@ -42,9 +46,7 @@ module.exports = function () {
         this.textboxEl.addEventListener('blur', this._onBlurListener);
         this.textboxEl.addEventListener('focus', this._onFocusListener);
 
-        // check for computed background color because of Chrome autofill bug
-        var isAutofilled = getComputedStyle(this.textboxEl).backgroundColor === 'rgb(250, 255, 189)';
-        if (!hasValue(this.textboxEl) && !isAutofilled) {
+        if (!hasValue(this.textboxEl) && !isAutofilled(this.textboxEl)) {
             this.labelEl.classList.add(this.options.labelElementInlineModifier);
         }
     }
@@ -52,7 +54,7 @@ module.exports = function () {
     _createClass(_class, [{
         key: 'refresh',
         value: function refresh() {
-            if (hasValue(this.textboxEl)) {
+            if (hasValue(this.textboxEl) || isAutofilled(this.textboxEl)) {
                 this.labelEl.classList.remove(this.options.labelElementInlineModifier);
             } else {
                 this.labelEl.classList.add(this.options.labelElementInlineModifier);

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ module.exports = function () {
             if (!hasValue(this.textboxEl) && !isAutofilled) {
                 this.labelEl.classList.add(this.options.labelElementInlineModifier);
             }
-        });
+        }.bind(this));
     }
 
     _createClass(_class, [{

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,8 @@ module.exports = class {
         this.textboxEl.addEventListener('blur', this._onBlurListener);
         this.textboxEl.addEventListener('focus', this._onFocusListener);
 
-        if (!hasValue(this.textboxEl)) {
+        // check for computed background color because of Chrome autofill bug
+        if (!hasValue(this.textboxEl) && getComputedStyle(this.textboxEl).backgroundColor !== `rgb(250, 255, 189)`) {
             this.labelEl.classList.add(this.options.labelElementInlineModifier);
         }
     }

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,10 @@ function hasValue(input) {
     return input.value.length > 0;
 }
 
+function isAutofilled(input) {
+    return getComputedStyle(input).backgroundColor === `rgb(250, 255, 189)`;
+}
+
 function _onBlur() {
     if (!hasValue(this.textboxEl)) {
         this.labelEl.classList.add(this.options.labelElementInlineModifier);
@@ -34,15 +38,13 @@ module.exports = class {
         this.textboxEl.addEventListener('blur', this._onBlurListener);
         this.textboxEl.addEventListener('focus', this._onFocusListener);
 
-        // check for computed background color because of Chrome autofill bug
-        const isAutofilled = getComputedStyle(this.textboxEl).backgroundColor === `rgb(250, 255, 189)`;
-        if (!hasValue(this.textboxEl) && !isAutofilled) {
+        if (!hasValue(this.textboxEl) && !isAutofilled(this.textboxEl)) {
             this.labelEl.classList.add(this.options.labelElementInlineModifier);
         }
     }
 
     refresh() {
-        if (hasValue(this.textboxEl)) {
+        if (hasValue(this.textboxEl) || isAutofilled(this.textboxEl)) {
             this.labelEl.classList.remove(this.options.labelElementInlineModifier);
         } else {
             this.labelEl.classList.add(this.options.labelElementInlineModifier);

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,8 @@ function hasValue(input) {
 }
 
 function isAutofilled(input) {
+    // check for computed background color because of Chrome autofill bug
+    // https://stackoverflow.com/questions/35049555/chrome-autofill-autocomplete-no-value-for-password/35783761#35783761
     return getComputedStyle(input).backgroundColor === `rgb(250, 255, 189)`;
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -35,12 +35,10 @@ module.exports = class {
         this.textboxEl.addEventListener('focus', this._onFocusListener);
 
         // check for computed background color because of Chrome autofill bug
-        window.addEventListener('load', function() {
-            const isAutofilled = getComputedStyle(this.textboxEl).backgroundColor === `rgb(250, 255, 189)`;
-            if (!hasValue(this.textboxEl) && !isAutofilled) {
-                this.labelEl.classList.add(this.options.labelElementInlineModifier);
-            }
-        }.bind(this));
+        const isAutofilled = getComputedStyle(this.textboxEl).backgroundColor === `rgb(250, 255, 189)`;
+        if (!hasValue(this.textboxEl) && !isAutofilled) {
+            this.labelEl.classList.add(this.options.labelElementInlineModifier);
+        }
     }
 
     refresh() {

--- a/src/index.js
+++ b/src/index.js
@@ -35,9 +35,12 @@ module.exports = class {
         this.textboxEl.addEventListener('focus', this._onFocusListener);
 
         // check for computed background color because of Chrome autofill bug
-        if (!hasValue(this.textboxEl) && getComputedStyle(this.textboxEl).backgroundColor !== `rgb(250, 255, 189)`) {
-            this.labelEl.classList.add(this.options.labelElementInlineModifier);
-        }
+        window.addEventListener('load', function() {
+            const isAutofilled = getComputedStyle(this.textboxEl).backgroundColor === `rgb(250, 255, 189)`;
+            if (!hasValue(this.textboxEl) && !isAutofilled) {
+                this.labelEl.classList.add(this.options.labelElementInlineModifier);
+            }
+        });
     }
 
     refresh() {

--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ module.exports = class {
             if (!hasValue(this.textboxEl) && !isAutofilled) {
                 this.labelEl.classList.add(this.options.labelElementInlineModifier);
             }
-        });
+        }.bind(this));
     }
 
     refresh() {

--- a/test/static/bundle-module.js
+++ b/test/static/bundle-module.js
@@ -42,7 +42,8 @@ module.exports = function () {
         this.textboxEl.addEventListener('blur', this._onBlurListener);
         this.textboxEl.addEventListener('focus', this._onFocusListener);
 
-        if (!hasValue(this.textboxEl)) {
+        // check for computed background color because of Chrome autofill bug
+        if (!hasValue(this.textboxEl) && getComputedStyle(this.textboxEl).backgroundColor !== 'rgb(250, 255, 189)') {
             this.labelEl.classList.add(this.options.labelElementInlineModifier);
         }
     }

--- a/test/static/bundle-module.js
+++ b/test/static/bundle-module.js
@@ -43,12 +43,10 @@ module.exports = function () {
         this.textboxEl.addEventListener('focus', this._onFocusListener);
 
         // check for computed background color because of Chrome autofill bug
-        window.addEventListener('load', function () {
-            var isAutofilled = getComputedStyle(this.textboxEl).backgroundColor === 'rgb(250, 255, 189)';
-            if (!hasValue(this.textboxEl) && !isAutofilled) {
-                this.labelEl.classList.add(this.options.labelElementInlineModifier);
-            }
-        }.bind(this));
+        var isAutofilled = getComputedStyle(this.textboxEl).backgroundColor === 'rgb(250, 255, 189)';
+        if (!hasValue(this.textboxEl) && !isAutofilled) {
+            this.labelEl.classList.add(this.options.labelElementInlineModifier);
+        }
     }
 
     _createClass(_class, [{

--- a/test/static/bundle-module.js
+++ b/test/static/bundle-module.js
@@ -16,6 +16,8 @@ function hasValue(input) {
 }
 
 function isAutofilled(input) {
+    // check for computed background color because of Chrome autofill bug
+    // https://stackoverflow.com/questions/35049555/chrome-autofill-autocomplete-no-value-for-password/35783761#35783761
     return getComputedStyle(input).backgroundColor === 'rgb(250, 255, 189)';
 }
 

--- a/test/static/bundle-module.js
+++ b/test/static/bundle-module.js
@@ -43,9 +43,12 @@ module.exports = function () {
         this.textboxEl.addEventListener('focus', this._onFocusListener);
 
         // check for computed background color because of Chrome autofill bug
-        if (!hasValue(this.textboxEl) && getComputedStyle(this.textboxEl).backgroundColor !== 'rgb(250, 255, 189)') {
-            this.labelEl.classList.add(this.options.labelElementInlineModifier);
-        }
+        window.addEventListener('load', function () {
+            var isAutofilled = getComputedStyle(this.textboxEl).backgroundColor === 'rgb(250, 255, 189)';
+            if (!hasValue(this.textboxEl) && !isAutofilled) {
+                this.labelEl.classList.add(this.options.labelElementInlineModifier);
+            }
+        });
     }
 
     _createClass(_class, [{

--- a/test/static/bundle-module.js
+++ b/test/static/bundle-module.js
@@ -15,6 +15,10 @@ function hasValue(input) {
     return input.value.length > 0;
 }
 
+function isAutofilled(input) {
+    return getComputedStyle(input).backgroundColor === 'rgb(250, 255, 189)';
+}
+
 function _onBlur() {
     if (!hasValue(this.textboxEl)) {
         this.labelEl.classList.add(this.options.labelElementInlineModifier);
@@ -42,9 +46,7 @@ module.exports = function () {
         this.textboxEl.addEventListener('blur', this._onBlurListener);
         this.textboxEl.addEventListener('focus', this._onFocusListener);
 
-        // check for computed background color because of Chrome autofill bug
-        var isAutofilled = getComputedStyle(this.textboxEl).backgroundColor === 'rgb(250, 255, 189)';
-        if (!hasValue(this.textboxEl) && !isAutofilled) {
+        if (!hasValue(this.textboxEl) && !isAutofilled(this.textboxEl)) {
             this.labelEl.classList.add(this.options.labelElementInlineModifier);
         }
     }
@@ -52,7 +54,7 @@ module.exports = function () {
     _createClass(_class, [{
         key: 'refresh',
         value: function refresh() {
-            if (hasValue(this.textboxEl)) {
+            if (hasValue(this.textboxEl) || isAutofilled(this.textboxEl)) {
                 this.labelEl.classList.remove(this.options.labelElementInlineModifier);
             } else {
                 this.labelEl.classList.add(this.options.labelElementInlineModifier);

--- a/test/static/bundle-module.js
+++ b/test/static/bundle-module.js
@@ -48,7 +48,7 @@ module.exports = function () {
             if (!hasValue(this.textboxEl) && !isAutofilled) {
                 this.labelEl.classList.add(this.options.labelElementInlineModifier);
             }
-        });
+        }.bind(this));
     }
 
     _createClass(_class, [{


### PR DESCRIPTION
Hey, guess what? Chrome's computed color gives away the secret that there is some autofilled content in there. And, you must wait for the window's load event to complete because the autofilled content won't be there until the very end.

Yeah. I know. 😞 

But hey, it works!